### PR TITLE
✨ fix: login dto response body

### DIFF
--- a/src/main/java/com/demoboletto/dto/response/AppleLoginResponseDto.java
+++ b/src/main/java/com/demoboletto/dto/response/AppleLoginResponseDto.java
@@ -1,0 +1,30 @@
+package com.demoboletto.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "Apple Login Response Dto")
+public record AppleLoginResponseDto(
+        @JsonProperty("accessToken")
+        @Schema(description = "액세스 토큰")
+        String accessToken,
+
+        @JsonProperty("refreshToken")
+        @Schema(description = "리프레시 토큰")
+        String refreshToken,
+
+        @JsonProperty("userName")
+        @Schema(description = "유저의 이름", example = "이다은")
+        String name,
+
+        @JsonProperty("userNickName")
+        @Schema(description = "유저의 닉네임", example = "leeeunda")
+        String nickname,
+
+        @JsonProperty("userProfile")
+        @Schema(description = "유저의 프로필 이미지 url", example = "https://boletto.s3.ap-northeast-2.amazonaws.com/스크린샷 2023-12-12 오후 12.49.20.png")
+        String userProfile
+) {
+}

--- a/src/main/java/com/demoboletto/dto/response/JwtTokenDto.java
+++ b/src/main/java/com/demoboletto/dto/response/JwtTokenDto.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.io.Serializable;
+
 
 @Builder
 @Schema(name = "JwtTokenDto", description = "JWT 토큰 응답")

--- a/src/main/java/com/demoboletto/dto/response/OAuthLoginResponseDto.java
+++ b/src/main/java/com/demoboletto/dto/response/OAuthLoginResponseDto.java
@@ -1,0 +1,28 @@
+package com.demoboletto.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "OAuth Login Response Dto")
+public record OAuthLoginResponseDto(
+        @JsonProperty("accessToken")
+        @Schema(description = "액세스 토큰")
+        String accessToken,
+
+        @JsonProperty("refreshToken")
+        @Schema(description = "리프레시 토큰")
+        String refreshToken,
+
+        @JsonProperty("userName")
+        @Schema(description = "유저의 이름", example = "홍길동")
+        String name,
+
+        @JsonProperty("userNickName")
+        @Schema(description = "유저의 닉네임", example = "길동이")
+        String nickname,
+
+        @JsonProperty("userProfile")
+        @Schema(description = "유저의 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String userProfile
+) {
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 로그인 시 유저의 이름, 닉네임, 프로필 이미지를 같이 반환하도록 하여 라우터 설정이 가능하도록 합니다.
- 탈퇴 후 애플 재로그인시 생겼던 문제를 해결합니다.

## 🔧 앞으로의 과제

- 추후 탈퇴 후 바로 재가입을 못하도록 설정을 추가합니다.