### PR TITLE
feat: change Alarm Domain & add AlarmType

### DIFF
--- a/src/main/java/com/demoboletto/domain/Alarm.java
+++ b/src/main/java/com/demoboletto/domain/Alarm.java
@@ -1,11 +1,9 @@
 package com.demoboletto.domain;
-
+import com.demoboletto.type.EAlarmType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -17,20 +15,16 @@ public class Alarm {
     @Column(name = "alarm_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable=true)
-    private User user;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "alarm_type")
+    private EAlarmType alarmType;
 
-    @Column(name = "contents")
-    private String contents;
-
-    @Column(name="alarm_status")
-    private Boolean alarmStatus;
+    @Column(name = "message")
+    private String message;
 
     @Builder
-    public Alarm(User user, String contents, Boolean alarmStatus) {
-        this.user = user;
-        this.contents = contents;
-        this.alarmStatus = alarmStatus;
+    public Alarm(EAlarmType alarmType, String message) {
+        this.alarmType = alarmType;
+        this.message = message;
     }
 }

--- a/src/main/java/com/demoboletto/domain/AlarmSettings.java
+++ b/src/main/java/com/demoboletto/domain/AlarmSettings.java
@@ -1,11 +1,8 @@
 package com.demoboletto.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -36,19 +33,14 @@ public class AlarmSettings {
     @Column(name = "location_sharing_consent")
     private Boolean locationSharingConsent;
 
-    @Column(name = "created_date")
-    private LocalDateTime createdDate;
-
-    @Builder
-    public AlarmSettings(User user, Boolean allNotifications,
-                                Boolean stickerFrameNotifications, Boolean friendRequestNotifications,
-                                Boolean travelInvitationNotifications, Boolean locationSharingConsent) {
+    public AlarmSettings(User user, Boolean allNotifications, Boolean stickerFrameNotifications,
+                         Boolean friendRequestNotifications, Boolean travelInvitationNotifications,
+                         Boolean locationSharingConsent) {
         this.user = user;
         this.allNotifications = allNotifications;
         this.stickerFrameNotifications = stickerFrameNotifications;
         this.friendRequestNotifications = friendRequestNotifications;
         this.travelInvitationNotifications = travelInvitationNotifications;
         this.locationSharingConsent = locationSharingConsent;
-        this.createdDate = new LocalDateTime();
     }
 }

--- a/src/main/java/com/demoboletto/domain/UserAlarm.java
+++ b/src/main/java/com/demoboletto/domain/UserAlarm.java
@@ -1,0 +1,46 @@
+package com.demoboletto.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Table(name = "user_alarm")
+public class UserAlarm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_alarm_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "template_id", nullable = false)
+    private Alarm alarmTemplate;
+
+    @Column(name = "is_read")
+    private Boolean isRead = false;
+
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @Builder
+    public UserAlarm(User user, Alarm alarmTemplate) {
+        this.user = user;
+        this.alarmTemplate = alarmTemplate;
+        this.createdDate = LocalDateTime.now();
+    }
+
+    // 알림 읽음 처리
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}
+

--- a/src/main/java/com/demoboletto/repository/UserRepository.java
+++ b/src/main/java/com/demoboletto/repository/UserRepository.java
@@ -14,6 +14,9 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    @Query("SELECT u FROM User u WHERE u.id = :userId")
+    Optional<User> findByUserId(@Param("userId") Long userId);
+
     Optional<User> findBySerialId(String serialId);
     Boolean existsBySerialId(String serialId);
 

--- a/src/main/java/com/demoboletto/service/UserService.java
+++ b/src/main/java/com/demoboletto/service/UserService.java
@@ -7,9 +7,12 @@ import com.demoboletto.dto.request.UserProfileUpdateDto;
 import com.demoboletto.dto.response.GetUserInfoDto;
 import com.demoboletto.exception.CommonException;
 import com.demoboletto.repository.*;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.origin.SystemEnvironmentOrigin;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -105,6 +108,8 @@ public class UserService {
 
         User user=userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+        log.info(user.toString());
+
         userRepository.delete(user);
     }
 }

--- a/src/main/java/com/demoboletto/type/EAlarmType.java
+++ b/src/main/java/com/demoboletto/type/EAlarmType.java
@@ -1,0 +1,16 @@
+package com.demoboletto.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EAlarmType {
+    STICKER_ACQUISITION("{stickerName} 스티커를 획득했어요."),
+    REGION_ACTIVATION("'{regionName}' 네컷 제작이 활성화되었어요."),
+    REGION_DEACTIVATION("'{regionName}' 네컷 제작이 비활성화되었어요."),
+    TRAVEL_TICKET("초대받은 여행 티켓이 {ticketCount}개 있어요."),
+    FRIEND_INVITE_SENT("친구에게 초대를 전송했어요");
+
+    private final String template;
+}

--- a/src/main/java/com/demoboletto/type/ESticker.java
+++ b/src/main/java/com/demoboletto/type/ESticker.java
@@ -22,5 +22,6 @@ public enum ESticker {
     BS, // BIFF Square
     GDB, // Gwangandaegyo Bridge
     HB, // Haeundae Beach
-    BCC // Busan Cinema Center
+    BCC, // Busan Cinema Center
+    KHU
 }


### PR DESCRIPTION
## 🔎 작업 내용

### **`AlarmSettings`** (알림 설정)
사용자가 어떤 유형의 알림을 받을지 설정을 저장합니다. 각 사용자별로 설정된 알림 수신 여부를 관리합니다.

### **`UserAlarm`** (사용자별 알림)
개별 사용자가 받은 알림과 그 알림의 읽음 여부를 저장합니다. `AlarmTemplate`을 참조하여 고정된 알림 형식과 사용자 정보를 연결합니다.

### **`Alarm`** (알람 템플릿)
반복되는 알림 형식을 간편하게 관리하기 위해 알림 템플릿 시스템을 도입합니다.