### PR TITLE
fix: SignOut Error By PersistenContext

### DIFF
--- a/src/main/java/com/demoboletto/domain/Collect.java
+++ b/src/main/java/com/demoboletto/domain/Collect.java
@@ -21,7 +21,7 @@ public class Collect {
     @Column(name = "collect_id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/demoboletto/repository/UserAlarmRepository.java
+++ b/src/main/java/com/demoboletto/repository/UserAlarmRepository.java
@@ -1,0 +1,13 @@
+package com.demoboletto.repository;
+
+import com.demoboletto.domain.UserAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
+
+    List<UserAlarm> findByUserId(Long id);
+}

--- a/src/main/java/com/demoboletto/service/UserService.java
+++ b/src/main/java/com/demoboletto/service/UserService.java
@@ -34,6 +34,7 @@ public class UserService {
     private final PictureRepository pictureRepository;
     private final FriendRepository friendRepository;
     private final AWSS3Service awsS3Service;
+    private final UserAlarmRepository userAlarmRepository;
 
     // 유저의 이름과 닉네임을 조회
     public GetUserInfoDto getUserNameAndNickname(Long userId) {
@@ -89,41 +90,53 @@ public class UserService {
 
     @Transactional
     public void deleteUser(Long userId) {
-        System.out.println("User ID: " + userId);
+        log.info("User ID: " + userId);
 
+        // UserTravel 삭제 (User는 삭제해도 되지만 Travel은 삭제되면 안 됨)
         List<UserTravel> userTravels = userTravelRepository.findByUserId(userId);
         if (!userTravels.isEmpty()) {
             userTravelRepository.deleteAll(userTravels);
         }
 
+        // Collect 삭제
         List<Collect> collects = collectRepository.findByUserId(userId);
         if (!collects.isEmpty()) {
             collectRepository.deleteAll(collects);
         }
 
+        // Picture는 soft delete로 처리 (User와의 관계만 끊음, 실제 삭제는 안 함)
         List<Picture> pictures = pictureRepository.findByUserId(userId);
         if (!pictures.isEmpty()) {
             pictures.forEach(picture -> {
                 picture.setDeleted(true);  // soft delete
-                picture.setUser(null);
+                picture.setUser(null);  // User와의 관계만 끊음
                 pictureRepository.save(picture);
             });
         }
 
+        // Friend 관련 데이터 삭제 (친구 목록 삭제)
         List<Friend> friends = friendRepository.findByUserId(userId);
         if (!friends.isEmpty()) {
             friendRepository.deleteAll(friends);
         }
 
+        // 다른 유저의 친구 목록에서 해당 유저 삭제
         List<Friend> friendsOfOthers = friendRepository.findByFriendUserId(userId);
         if (!friendsOfOthers.isEmpty()) {
             friendRepository.deleteAll(friendsOfOthers);
         }
 
-        User user=userRepository.findById(userId)
-                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
-        log.info(user.toString());
+        // 유저 알림 데이터 삭제
+        List<UserAlarm> userAlarms = userAlarmRepository.findByUserId(userId);
+        if (!userAlarms.isEmpty()) {
+            userAlarmRepository.deleteAll(userAlarms);
+        }
 
+        // 마지막으로 유저 삭제
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+
+        log.info("Deleting user: " + user.toString());
         userRepository.delete(user);
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- JPA의 영속성 컨텍스트로 인해 생긴 회원탈퇴 에러를 해결합니다.
- Collection 도메인의 Cascade Delete때문에, 유저가 삭제가 되고 나서 찾으려고 하기 때문에 Not found User 에러가 뜸 → 트랜잭션 롤백 → 삭제가 안됨